### PR TITLE
fixed error on macos due to no write permissions to /usr/bin

### DIFF
--- a/install
+++ b/install
@@ -19,4 +19,9 @@ fi
 
 mkdir $installdir
 cp ./config/* $installdir
-cp ./pywal-discord /usr/bin/
+if [ "${unameOut}" == "Darwin" ]
+then
+	cp ./pywal-discord /usr/local/bin
+else
+	cp ./pywal-discord /usr/bin/
+fi


### PR DESCRIPTION
Fixed an error "Read-only file system" on macos.

On mac, it now writes ./pywal-discord to /usr/local/bin, but stays in /usr/bin/ for linux.