### PR TITLE
Uses $HOME/.config to find custom themes

### DIFF
--- a/install
+++ b/install
@@ -6,19 +6,25 @@ then
 fi
 
 installdir=/usr/share/pywal-discord
+themesdir=$HOME/.config/pywal-discord
 
 unameOut="$(uname -s)"
 case "${unameOut}" in
-    Darwin*)    installdir=$HOME/.config/pywal-discord;;
+    Darwin*)
+        installdir=$HOME/.config/pywal-discord
+        themesdir=$HOME/.config/pywal-discord-themes
+        ;;
 esac
 
-if [ -e $installdir ]
+mkdir -p "$themesdir"
+
+if [ -e "$installdir" ]
 then
-	rm -rf $installdir
+	rm -rf "$installdir"
 fi
 
-mkdir $installdir
-cp ./config/* $installdir
+mkdir "$installdir"
+cp ./config/* "$installdir"
 if [ "${unameOut}" == "Darwin" ]
 then
 	cp ./pywal-discord /usr/local/bin

--- a/pywal-discord
+++ b/pywal-discord
@@ -2,11 +2,13 @@
 path="$HOME/.config/BetterDiscord/themes"
 theme="default"
 config="/usr/share/pywal-discord"
+usrconfig="$HOME/.config/pywal-discord"
 
 unameOut="$(uname -s)"
 case "${unameOut}" in
     Darwin*)    config="$HOME/.config/pywal-discord"
                 path="$HOME/Library/Preferences/BetterDiscord/themes"
+                usrconfig="$HOME/.config/pywal-discord-themes"
         ;;
 esac
 
@@ -20,7 +22,7 @@ print_usage() {
 
 while getopts 'dp:vt:vh' flag; do
   case "${flag}" in
-    d) mkdir -p $path ;;
+    d) mkdir -p "$path" ;;
     p) path="${OPTARG}" ;;
     t) theme="${OPTARG}" ;;
     h) print_usage ;;
@@ -29,11 +31,19 @@ while getopts 'dp:vt:vh' flag; do
   esac
 done
 
+# Try to use a user defined theme if it exists
+themefile=$usrconfig/pywal-discord-$theme.css
+if [ ! -f "$themefile" ]; then
+  themefile=$config/pywal-discord-$theme.css
+fi
+
 newfile=$path/pywal-discord-$theme.theme.css
 
+# Adapt metadata to theme
+sed "s/@name Pywal-Discord/@name Pywal-Discord-$theme/" "$config/meta.css" > /tmp/pywal-discord-meta
 
-cat $config/meta.css $HOME/.cache/wal/colors.css $config/pywal-discord-$theme.css > $newfile 
-if [ ! -f $newfile ]
+cat /tmp/pywal-discord-meta "$HOME/.cache/wal/colors.css" "$themefile" > "$newfile" 
+if [ ! -f "$newfile" ]
 then
     echo ⚠️ THEME WAS NOT CREATED ⚠️ 
     echo Try to change path with -p because $path doesn\'t exist, or add -d to create it

--- a/readme.md
+++ b/readme.md
@@ -27,6 +27,14 @@ cd pywal-discord
 
 [![gif](https://raw.githubusercontent.com/FilipLitwora/pywal-discord/master/images/out.gif)](https://www.youtube.com/watch?v=HZ7CXAt3N2Y)
 
+#### Configuration
+
+Add your themes to `$HOME/.config/pywal-discord/` (`$HOME/.config/pywal-discord-themes/` on MacOS) following the `pywal-discord-<theme_name>.css` format.
+
+You can copy `/usr/share/pywal-discord/pywal-discord-default.css` to use as a template.
+
+To use the themes simply call `pywal-discord -t <theme_name>`.
+
 ### Theme made by <a href="https://github.com/abou123" target="_blank">abou123</a>
 
 to use this theme


### PR DESCRIPTION
Right now if I want to make a custom theme I have to put it in the installation folder, which is not ideal.
This PR makes it so that users can override/add themes in their config folder.
I tried to make so that it works on mac too but it might need a little bit of testing.